### PR TITLE
fix: add missing /collections /profile /marketplace routes

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import CollectionCard from "@/components/CollectionCard";
+import { COLLECTIONS } from "@/lib/mock-data";
+
+export default function CollectionsPage() {
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search) return COLLECTIONS;
+    const q = search.toLowerCase();
+    return COLLECTIONS.filter((c) => c.name.toLowerCase().includes(q));
+  }, [search]);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-8 text-3xl font-bold">Collections</h1>
+
+      {/* Search */}
+      <div className="mb-8 rounded-xl border border-gray-800 bg-gray-800/30 p-4">
+        <input
+          type="text"
+          placeholder="Search collections..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white outline-none placeholder:text-gray-500 focus:border-purple-500"
+        />
+      </div>
+
+      {/* Results */}
+      {filtered.length === 0 ? (
+        <div className="py-20 text-center text-gray-500">
+          <p className="text-4xl mb-4">🔍</p>
+          <p>No collections found</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filtered.map((collection) => (
+            <CollectionCard key={collection.address} collection={collection} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MarketplacePage() {
+  redirect("/explore");
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useWallet } from "@/context/WalletContext";
+
+export default function ProfileIndexPage() {
+  const { address, isConnected, connect } = useWallet();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isConnected && address) {
+      router.replace(`/profile/${address}`);
+    }
+  }, [isConnected, address, router]);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <div className="flex flex-col items-center justify-center py-20">
+        <div className="mb-6 text-6xl">👤</div>
+        <h1 className="mb-4 text-2xl font-bold">Connect Your Wallet</h1>
+        <p className="mb-8 text-gray-400">
+          Connect your wallet to view your profile, owned NFTs, and activity.
+        </p>
+        <button
+          onClick={connect}
+          className="rounded-lg bg-purple-600 px-8 py-3 font-semibold text-white transition hover:bg-purple-700"
+        >
+          Connect Wallet
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #1

- `/collections` — collections index page with search filter and CollectionCard grid
- `/profile` — wallet connect prompt; redirects to `/profile/[address]` when connected
- `/marketplace` — server-side redirect to `/explore`

🤖 *Submitted by Aria Tanaka（田中爱莉）, QA Engineer @ QFC Network — via OpenClaw*